### PR TITLE
[SA-15302] Parse Cookie header and its attrs. Use the sessionid as mark for upstream socket

### DIFF
--- a/src/event/ngx_event_connect.c
+++ b/src/event/ngx_event_connect.c
@@ -73,6 +73,16 @@ ngx_event_connect_peer(ngx_peer_connection_t *pc)
         }
     }
 
+    if (pc->so_mark) {
+        if (setsockopt(s, SOL_SOCKET, SO_MARK,
+                       (const void *) &pc->so_mark, sizeof(uint32_t)) == -1)
+        {
+            ngx_log_error(NGX_LOG_ALERT, pc->log, ngx_socket_errno,
+                          "setsockopt(SO_MARK) failed");
+            goto failed;
+        }
+    }
+
     if (pc->so_keepalive) {
         value = 1;
 

--- a/src/event/ngx_event_connect.h
+++ b/src/event/ngx_event_connect.h
@@ -57,6 +57,7 @@ struct ngx_peer_connection_s {
 
     int                              type;
     int                              rcvbuf;
+    uint32_t                         so_mark;
 
     ngx_log_t                       *log;
 

--- a/src/http/ngx_http_upstream.h
+++ b/src/http/ngx_http_upstream.h
@@ -172,6 +172,7 @@ typedef struct {
     ngx_uint_t                       next_upstream;
     ngx_uint_t                       store_access;
     ngx_uint_t                       next_upstream_tries;
+    ngx_flag_t                       so_marking;
     ngx_flag_t                       buffering;
     ngx_flag_t                       request_buffering;
     ngx_flag_t                       pass_request_headers;
@@ -388,6 +389,7 @@ struct ngx_http_upstream_s {
     unsigned                         cache_status:3;
 #endif
 
+    unsigned                         so_marking:1;
     unsigned                         buffering:1;
     unsigned                         keepalive:1;
     unsigned                         upgrade:1;


### PR DESCRIPTION
```
curl  -i -H "Cookie: sessionid=0x127f" http://172.17.103.2

[info] 25160#25160: *10 proxy_pass: "sessionid: 0x127f", client: 192.168.100.2, server: , request: "GET / HTTP/1.1", host: "172.17.103.2"

Chain OUTPUT (policy ACCEPT 25 packets, 1684 bytes)
 pkts bytes target     prot opt in     out     source               destination         
    9   468 LOG        all  --  *      *       0.0.0.0/0            0.0.0.0/0            mark match 0x127f LOG flags 0 level 4